### PR TITLE
img_path is redundant and breaks plugin

### DIFF
--- a/better_figures_and_images/better_figures_and_images.py
+++ b/better_figures_and_images/better_figures_and_images.py
@@ -57,7 +57,7 @@ def content_object_init(instance):
                 # 2. Build the source image filename from STATIC_PATHS
                 src = os.path.join(instance.settings['PATH'], img_path, img_filename)
                 src_candidates = [src]
-                src_candidates += [os.path.join(instance.settings['PATH'], static_path, img_path, img_filename) for static_path in instance.settings['STATIC_PATHS']]
+                src_candidates += [os.path.join(instance.settings['PATH'], static_path, img_filename) for static_path in instance.settings['STATIC_PATHS']]
                 src_candidates = [f for f in src_candidates if path.isfile(f) and access(f, R_OK)]
 
                 if not src_candidates:


### PR DESCRIPTION
markdown expects {filename}/images/file.jpg format, with leading forward slash. This is exemplified by the fact that if you try to rectify this bug bug leaving off the leading slashing, the following error is produced:

```
> /usr/lib/python2.7/site-packages/pelican/generators.py(587)generate_output()
-> self.generate_pages(writer)
(Pdb) n
WARNING: Unable to find `images/dnf_changelog.png`, skipping url replacement.
```

Presumably we only care about candidates if they're in a proper static path, so img_path is redundant and will produce results like `images/images`, which then leads to `if no src_candidates` being false. (which is the original bug)